### PR TITLE
Make the SBT plugin more consistent with the Maven plugin and follow SBT plugin best practices

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ To add this to your project, add the following to your build:
 addSbtPlugin("org.musigma" % "sbt-rat" % "0.5.1")
 ----
 
-This adds two tasks: `auditCheck` and `auditReport`.
+This adds two tasks: `ratCheck` and `ratReport`.
 The first task will fail the build if the audit check fails.
 The second task generates the audit report files (plain text and AsciiDoc).
 

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ To add this to your project, add the following to your build:
 .project/plugins.sbt
 [source,scala]
 ----
-addSbtPlugin("org.musigma" % "sbt-rat" % "0.5.1")
+addSbtPlugin("org.musigma" % "sbt-rat" % "0.5.2")
 ----
 
 This adds two tasks: `ratCheck` and `ratReport`.

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ To add this to your project, add the following to your build:
 .project/plugins.sbt
 [source,scala]
 ----
-addSbtPlugin("org.musigma" % "sbt-rat" % "0.5.2")
+addSbtPlugin("org.musigma" % "sbt-rat" % "0.6.0")
 ----
 
 This adds two tasks: `ratCheck` and `ratReport`.

--- a/src/main/java/org/apache/rat/mp/util/ScmIgnoreParser.java
+++ b/src/main/java/org/apache/rat/mp/util/ScmIgnoreParser.java
@@ -1,0 +1,113 @@
+package org.apache.rat.mp.util;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.apache.commons.io.IOUtils;
+import org.apache.rat.config.SourceCodeManagementSystems;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Helper to parse SCM ignore files to add entries as excludes during RAT runs.
+ * Since we log errors it needs to reside inside of the maven plugin.
+ */
+public final class ScmIgnoreParser {
+    private ScmIgnoreParser() {
+        // prevent instantiation of utility class
+    }
+
+    private static List<String> COMMENT_PREFIXES = Arrays.asList("#", "##", "//", "/**", "/*");
+
+    /**
+     * Parses excludes from the given SCM ignore file.
+     *
+     * @param scmIgnore if <code>null</code> or invalid an empty list of exclusions is returned.
+     * @return all exclusions (=non-comment lines) from the SCM ignore file.
+     */
+    public static List<String> getExcludesFromFile(final File scmIgnore) {
+
+        final List<String> exclusionLines = new ArrayList<String>();
+
+        if (scmIgnore != null && scmIgnore.exists() && scmIgnore.isFile()) {
+            BufferedReader reader = null;
+            try {
+                reader = new BufferedReader(new FileReader(scmIgnore));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (!isComment(line)) {
+                        exclusionLines.add(line);
+                    }
+                }
+            } catch (final IOException e) {
+                System.err.println("Cannot parse " + scmIgnore + " for exclusions. Will skip this file.");
+                System.err.println("Skip parsing " + scmIgnore + " due to " + e.getMessage());
+            } finally {
+                IOUtils.closeQuietly(reader);
+            }
+        }
+        return exclusionLines;
+    }
+
+    /**
+     * Parse ignore files from all known SCMs that have ignore files.
+     *
+     * @param baseDir base directory from which to look for SCM ignores.
+     * @return Exclusions from the SCM ignore files.
+     */
+    public static List<String> getExclusionsFromSCM(final File baseDir) {
+        List<String> exclusions = new ArrayList<String>();
+        for (SourceCodeManagementSystems scm : SourceCodeManagementSystems.values()) {
+            if (scm.hasIgnoreFile()) {
+                exclusions.addAll(getExcludesFromFile(new File(baseDir, scm.getIgnoreFile())));
+            }
+        }
+        return exclusions;
+
+    }
+
+    /**
+     * Determines whether the given line is a comment or not based on scanning
+     * for prefixes
+     * {@see COMMENT_PREFIXES}.
+     *
+     * @param line line to verify.
+     * @return <code>true</code> if the given line is a commented out line.
+     */
+    static boolean isComment(final String line) {
+        if (line == null || line.length() <= 0) {
+            return false;
+        }
+
+        final String trimLine = line.trim();
+        for (String prefix : COMMENT_PREFIXES) {
+            if (trimLine.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/scala/org/musigma/sbt/rat/SbtRatPlugin.scala
+++ b/src/main/scala/org/musigma/sbt/rat/SbtRatPlugin.scala
@@ -86,7 +86,13 @@ object SbtRatPlugin extends AutoPlugin {
       val customExclusionsFilter = customExclusions.foldLeft(NothingFilter: sbt.FileFilter) {
         case (filter: FileFilter, exclusion) => filter || new SimpleFileFilter(file => {
           val rel = baseDir.relativize(file)
-          rel.map { _.compareTo(exclusion) == 0 }.getOrElse(false)
+          rel.map { f =>
+            // excludes a file if either
+            // 1) the exclusion matches the exact path of the file
+            // 2) the exclusion does not contain a parent directory (i.e.
+            //    it's just a file name) and it matches the name of the file
+            f.compareTo(exclusion) == 0 || new java.io.File(f.getName).compareTo(exclusion) == 0
+          }.getOrElse(false)
         })
       }
 
@@ -182,6 +188,9 @@ object SbtRatPlugin extends AutoPlugin {
 
   override lazy val buildSettings: Seq[Setting[_]] = Nil
 
-  override lazy val globalSettings: Seq[Setting[_]] = Nil
+  override lazy val globalSettings: Seq[Setting[_]] = Seq(
+    aggregate in ratCheck := false,
+    aggregate in ratReport := false
+  )
 
 }

--- a/src/main/scala/org/musigma/sbt/rat/SbtRatPlugin.scala
+++ b/src/main/scala/org/musigma/sbt/rat/SbtRatPlugin.scala
@@ -175,19 +175,23 @@ object SbtRatPlugin extends AutoPlugin {
     )
   }
 
-  class UnapprovedLicenseException(found: Int, target: File)
-    extends RuntimeException(s"Unapproved licenses found: $found. See full report in $target")
+  class UnapprovedLicenseException()
+    extends RuntimeException("Unapproved licenses")
+    with FeedbackProvidedException
 
   def makeRatCheckSetting(): Setting[Task[Unit]] = {
-    def go(report: RatReport, target: File): Unit = {
-      if (report.getNumUnApproved > 0) {
-        throw new UnapprovedLicenseException(report.getNumUnApproved, target)
+    def go(report: RatReport, target: File, log: Logger): Unit = {
+      val numUnApproved = report.getNumUnApproved
+      if (numUnApproved > 0) {
+        log.error(s"Unapproved licenses found: $numUnApproved. See full report in $target")
+        throw new UnapprovedLicenseException
       }
     }
 
     ratCheck := go(
       ratReport.value,
-      ratTarget.value
+      ratTarget.value,
+      streams.value.log
     )
   }
 

--- a/src/sbt-test/sbt-rat/apache-headers/.gitignore
+++ b/src/sbt-test/sbt-rat/apache-headers/.gitignore
@@ -1,0 +1,2 @@
+global
+target

--- a/src/sbt-test/sbt-rat/apache-headers/build.sbt
+++ b/src/sbt-test/sbt-rat/apache-headers/build.sbt
@@ -1,2 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 version := "0.1"
 scalaVersion := "2.12.4"
+
+ratExcludes := Seq(
+  file(".gitignore"),
+  file("project/build.properties")
+)
+
+ratLicenses := Seq(
+  ("BSD3 ", BSD3_LICENSE_NAME, BSD3_LICENSE_TEXT)
+)
+
+ratLicenseFamilies := Seq(
+  BSD3_LICENSE_NAME
+)
+
+lazy val BSD3_LICENSE_NAME = "BSD 3-Clause License"
+lazy val BSD3_LICENSE_TEXT =
+"""
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""

--- a/src/sbt-test/sbt-rat/apache-headers/build.sbt
+++ b/src/sbt-test/sbt-rat/apache-headers/build.sbt
@@ -21,9 +21,10 @@ version := "0.1"
 scalaVersion := "2.12.4"
 
 ratExcludes := Seq(
-  file(".gitignore"),
   file("project/build.properties")
 )
+
+excludeFilter in ratReport := (excludeFilter in ratReport).value || ".gitignore"
 
 ratLicenses := Seq(
   ("BSD3 ", BSD3_LICENSE_NAME, BSD3_LICENSE_TEXT)

--- a/src/sbt-test/sbt-rat/apache-headers/src/main/scala/BSD3.scala
+++ b/src/sbt-test/sbt-rat/apache-headers/src/main/scala/BSD3.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2013, Someone
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package simple
+
+/**
+  * A simple class under a BSD3 license
+  */
+class BSD3 {
+  def method = "BSD3"
+}

--- a/src/sbt-test/sbt-rat/apache-headers/src/main/scala/BSD3.scala
+++ b/src/sbt-test/sbt-rat/apache-headers/src/main/scala/BSD3.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013, Someone
+ * Copyright (c) 2018, Stephen Lawrence
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/src/sbt-test/sbt-rat/apache-headers/test
+++ b/src/sbt-test/sbt-rat/apache-headers/test
@@ -1,8 +1,23 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+## 
+##  http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+## 
 # given source files with apache license headers
 # when we audit check
 # then it should succeed
-> auditCheck
+> ratCheck
 # and it should generate a rat report
 $ exists target/rat.txt
-# and it should generate an asciidoc version
-$ exists target/rat.adoc

--- a/src/sbt-test/sbt-rat/missing-headers/.gitignore
+++ b/src/sbt-test/sbt-rat/missing-headers/.gitignore
@@ -1,0 +1,2 @@
+global
+target

--- a/src/sbt-test/sbt-rat/missing-headers/build.sbt
+++ b/src/sbt-test/sbt-rat/missing-headers/build.sbt
@@ -1,2 +1,9 @@
 version := "0.1"
 scalaVersion := "2.12.4"
+
+ratExcludes := Seq(
+  file(".gitignore"),
+  file("project/build.properties")
+)
+
+ratReportStyle := "adoc"

--- a/src/sbt-test/sbt-rat/missing-headers/src/main/scala/BSD3.scala
+++ b/src/sbt-test/sbt-rat/missing-headers/src/main/scala/BSD3.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2013, Someone
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package simple
+
+/**
+  * A simple class under a BSD3 license
+  */
+class BSD3 {
+  def method = "BSD3"
+}

--- a/src/sbt-test/sbt-rat/missing-headers/src/main/scala/BSD3.scala
+++ b/src/sbt-test/sbt-rat/missing-headers/src/main/scala/BSD3.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013, Someone
+ * Copyright (c) 2018, Stephen Lawrence
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/src/sbt-test/sbt-rat/missing-headers/test
+++ b/src/sbt-test/sbt-rat/missing-headers/test
@@ -1,8 +1,6 @@
 # given source files with missing headers
 # when we audit check
 # then it should fail
--> auditCheck
-# and it should generate a rat report
-$ exists target/rat.txt
+-> ratCheck
 # and it should generate an asciidoc version
 $ exists target/rat.adoc

--- a/src/sbt-test/sbt-rat/plugins.sbt
+++ b/src/sbt-test/sbt-rat/plugins.sbt
@@ -1,1 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 addSbtPlugin("org.musigma" % "sbt-rat" % sys.props("plugin.version"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2-SNAPSHOT"
+version in ThisBuild := "0.5.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
- Modify the settings to be prefixed with the 'rat' namespace so as to
  prevent potential key collisions. Also rename some settings so that
  they are the same as the rat maven plugin for consistency. Rename
  auditReport and auditCheck to ratReport and ratCheck, since there may
  be other 'audit' tasks out there that might conflict.
- Rather than running rat checks on just unmanaged sources--which leaves
  out lots of files including resources, sbt configuration files, and
  files that sbt doesn't know about--recurse down the entire source
  directory and perform a check on all files. This also means that there
  is really no need for a separate configuration to run on compile vs
  test, so the Audit config is removed and Compile/Test config stuff is
  removed.
- The above change will now check lots of files that it shouldn't, like SCM
  files and sbt generated files. So add a new setting
  (ratParseSCMIgnoresAsExcludes) to parse SCM ignore files so that they
  can be excluded. Additionally, add a new setting (ratExclude) to
  provide specific files that should be ignored from a rat check. This
  is useful to exclude files that are tracked via SCM, but cannot include
  the Apache license header, for example test files.
- Add setting (ratReportStyle) to configure the report style. Users
  probably don't need to output two different types of reports. Rather
  than always outputting as both text and ascii doc, provide a setting
  to specify which style is preferred and only output that style. Modify
  tests so one uses txt and the other uses adoc.
- Remove the use of maxErrors. That key is really for just how many
  compile errors to display, not really how many errors constitutes a
  fatal error, which is sortof how this plugin was using it. Consistent
  with the maven plugin, it should be an error if _any_ unapproved
  licenses found, so maxErrors really isn't necessary.

Note that the ScmIngoreParser.java file is copied from the rat maven
plugin with minor modifications to remove logging support. Ideally that
function would be moved to rat-core since really all plugins could
benefit from the ability to use SCM ignores.